### PR TITLE
Quickfix for '--config' message and hooks not working

### DIFF
--- a/hooks.cpp
+++ b/hooks.cpp
@@ -5,7 +5,7 @@
 
 void Hooks::executeDockHook()
 {
-	int ret = system("/etc/dockd/dock.hook");
+	int ret = system("/bin/bash /etc/dockd/dock.hook");
 
 	if (ret == -1)
 		syslog(LOG_ERR, "Failed to execute dock hook");
@@ -15,7 +15,7 @@ void Hooks::executeDockHook()
 
 void Hooks::executeUndockHook()
 {
-	int ret = system("/etc/dockd/undock.hook");
+	int ret = system("/bin/bash /etc/dockd/undock.hook");
 
 	if (ret == -1)
 		syslog(LOG_ERR, "Failed to execute undock hook");

--- a/main.cpp
+++ b/main.cpp
@@ -135,7 +135,7 @@ int applyConfig(const char *state) {
                dockState == CRTControllerManager::DockState::DOCKED ? CONFIG_LOCATION_DOCKED : CONFIG_LOCATION_UNDOCKED);
 
     }
-
+	return EXIT_SUCCESS;
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
I'm not the author of the post, but I was experiencing the same issues as outlined here: https://aur.archlinux.org/packages/dockd#comment-726532

Fixes:

* hooks not executing 
* `config file written to ...` message spam on `--config`

I wasn't able to reproduce the issue w/r/t `--help` option segfaulting.