### PR TITLE
Fix missing return values for non-void functions

### DIFF
--- a/crtc.cpp
+++ b/crtc.cpp
@@ -329,6 +329,8 @@ bool CRTControllerManager::writeConfigToDisk(CRTControllerManager::DockState sta
         return ini.writeIni(CONFIG_LOCATION_UNDOCKED);
     }
 
+    return false;
+
 }
 
 CRTControllerManager::OutputConfigs CRTControllerManager::getOutputConfigs(vector<const char *> *configOutputNames,

--- a/main.cpp
+++ b/main.cpp
@@ -74,7 +74,7 @@ int startDaemon() {
     acpi.wait();
 
     closelog();
-
+    return EXIT_SUCCESS;
 }
 
 int showHelp() {
@@ -84,6 +84,7 @@ int showHelp() {
            "    dockd --config [docked|undocked]    - write config files\n"
            "    dockd --set [docked|undocked]       - set the saved config\n"
            "    dockd --daemon                      - start the dock daemon\n");
+    return EXIT_SUCCESS;
 }
 
 int writeConfig(const char *state) {
@@ -109,7 +110,7 @@ int writeConfig(const char *state) {
                dockState == CRTControllerManager::DockState::DOCKED ? CONFIG_LOCATION_DOCKED : CONFIG_LOCATION_UNDOCKED);
 
     }
-
+    return EXIT_SUCCESS;
 }
 
 int applyConfig(const char *state) {
@@ -135,6 +136,7 @@ int applyConfig(const char *state) {
                dockState == CRTControllerManager::DockState::DOCKED ? CONFIG_LOCATION_DOCKED : CONFIG_LOCATION_UNDOCKED);
 
     }
+    return EXIT_SUCCESS;
 
 }
 
@@ -186,5 +188,4 @@ int main(int argc, char *argv[])
     fprintf(stderr, "Unknown option: %s. See --help\n", argv[1]);
 
     return EXIT_FAILURE;
-
 }


### PR DESCRIPTION
During compilation, I encountered a number of warnings due to missing return values.

```
no return statement in function returning non-void [-Wreturn-type]
control reaches end of non-void function [-Wreturn-type]
```

As the binary after compilation also segfaulted for me, even with just `--help`, I figured maybe addressing them would help. And indeed, fixing those made the binary work reliably.